### PR TITLE
Add version as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This action sets two outputs:
 
 - `changed` : either "true" or "false", indicates whether the version has changed.
 - `type` : if the version has changed, it tries to find the type of bump (e.g. "patch", "minor", ...)
-- `version` : if the version has changed, it shows the nre version number (e.g. "1.0.2)
+- `version` : if the version has changed, it shows the version number (e.g. "1.0.2")
 
 To access these outputs, you need to access the context of the step you previously set up: you can find more info about steps contexts [here](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions#steps-context).  
 If you set your step id to `check` you'll find the outputs at `steps.check.outputs.changed`, `steps.check.outputs.type` and `steps.check.outputs.version`: you can use these outputs as conditions for other steps.  
@@ -44,8 +44,7 @@ Here's an example:
 
 - name: Log when changed
   if: steps.check.outputs.changed == 'true'
-  run: 'echo "Version change! -> ${{ steps.check.outputs.type }}"'
-  run: 'echo "Version found! -> ${{ steps.check.outputs.version }}"'
+  run: 'echo "Version change found! New version: ${{ steps.check.outputs.version }} (${{ steps.steps.check.outputs.type }})"'
 
 - name: Log when unchanged
   if: steps.check.outputs.changed != 'true'

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ This action sets two outputs:
 
 - `changed` : either "true" or "false", indicates whether the version has changed.
 - `type` : if the version has changed, it tries to find the type of bump (e.g. "patch", "minor", ...)
+- `version` : if the version has changed, it shows the nre version number (e.g. "1.0.2)
 
 To access these outputs, you need to access the context of the step you previously set up: you can find more info about steps contexts [here](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions#steps-context).  
-If you set your step id to `check` you'll find the outputs at `steps.check.outputs.changed` and `steps.check.outputs.type`: you can use these outputs as conditions for other steps.  
+If you set your step id to `check` you'll find the outputs at `steps.check.outputs.changed`, `steps.check.outputs.type` and `steps.check.outputs.version`: you can use these outputs as conditions for other steps.  
 Here's an example:
 
 ```yaml
@@ -44,6 +45,7 @@ Here's an example:
 - name: Log when changed
   if: steps.check.outputs.changed == 'true'
   run: 'echo "Version change! -> ${{ steps.check.outputs.type }}"'
+  run: 'echo "Version found! -> ${{ steps.check.outputs.version }}"'
 
 - name: Log when unchanged
   if: steps.check.outputs.changed != 'true'

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Version Check
 author: Federico Grandi
 description: An action that allows you to check whether your npm package version has been updated
 
-inputs: 
+inputs:
   diff-search:
     description: Whether to search the bump commit using diffs (recommended ONLY if not using standard 'npm version' commits)
     required: false
@@ -17,11 +17,13 @@ outputs:
   changed:
     description: Whether the version has changed in the examined commits
   type:
-    description: The type of version change, if detectable (e.g. 'patch')  
+    description: The type of version change, if detectable (e.g. 'patch')
+  version:
+    description: The detected version number
 
 runs:
   using: node12
-  main: 'lib/main.js'
+  main: "lib/main.js"
 
 branding:
   icon: package

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npm run compile && npm run minify && rm build/*.js",
     "compile": "tsc",
     "dist": "echo \"Preparing for distribution...\" && npm i --only=prod && git add -f node_modules && git commit -m \"Commit dist files\"",
+    "lint": "eslint ./src --ext ts && echo 'Lint complete.'",
     "minify": "minify build -d lib",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ const packageFileName = core.getInput('file-name') || 'package.json',
 type ArgValue<T> =
   T extends 'changed' ? boolean :
   T extends 'type' ? string | undefined :
+  T extends 'version' ? string | undefined :
   never
 
 async function main() {
@@ -194,6 +195,7 @@ async function checkDiff(sha: string, version: string) {
     if (versions.added != version) return false
 
     await setOutput('changed', true)
+    await setOutput('version', version)
     if (versions.deleted)
       await setOutput('type', semverDiff(versions.deleted, versions.added))
     return true
@@ -243,7 +245,7 @@ async function readJson(file: string) {
   return JSON.parse(data)
 }
 
-function setOutput<T extends 'changed' | 'type'>(name: T, value: ArgValue<T>) {
+function setOutput<T extends 'changed' | 'type' | 'version'>(name: T, value: ArgValue<T>) {
   return core.setOutput(name, `${value}`)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,14 +38,14 @@ function isPackageObj(value): value is PackageObj {
   return !!value && !!value.version
 }
 
-async function getCommit(sha: string): Promise<CommitReponse> {
+async function getCommit(sha: string): Promise<CommitResponse> {
   const url = `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/commits/${sha}`
   const headers = token ? {
     Authorization: `Bearer ${token}`
   } : undefined
   return (await axios.get(url, { headers })).data
 }
-interface CommitReponse {
+interface CommitResponse {
   url: string
   sha: string
   node_id: string
@@ -122,7 +122,7 @@ interface CommitReponse {
   }[]
   stats: {
     additions: number
-    deleteions: number
+    deletions: number
     total: number
   }
   files: {
@@ -198,7 +198,7 @@ async function checkDiff(sha: string, version: string) {
       await setOutput('type', semverDiff(versions.deleted, versions.added))
     return true
   } catch (e) {
-    console.error(`An error occured in checkDiff:\n${e}`)
+    console.error(`An error occurred in checkDiff:\n${e}`)
     throw new ExitError(1)
   }
 }
@@ -222,7 +222,7 @@ async function processDirectory(dir: string, commits: Commit[]) {
       throw new Error('Can\'t find version field')
 
     if (commits.length >= 20)
-      console.warn('This worflow run topped the commit limit set by GitHub webhooks: that means that commits could not appear and that the run could not find the version change.')
+      console.warn('This workflow run topped the commit limit set by GitHub webhooks: that means that commits could not appear and that the run could not find the version change.')
 
     await checkCommits(commits, packageObj.version)
   } catch (e) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -194,10 +194,10 @@ async function checkDiff(sha: string, version: string) {
     }
     if (versions.added != version) return false
 
-    await setOutput('changed', true)
-    await setOutput('version', version)
+    setOutput('changed', true)
+    setOutput('version', version)
     if (versions.deleted)
-      await setOutput('type', semverDiff(versions.deleted, versions.added))
+      setOutput('type', semverDiff(versions.deleted, versions.added))
     return true
   } catch (e) {
     console.error(`An error occurred in checkDiff:\n${e}`)


### PR DESCRIPTION
May be useful if you wan't to trigger a "create release" using this version number.

> Also fixed a few typos 

### Sample workflow fragment

```yaml
     - name: Check if version has been updated
        id: check
        uses: EndBug/version-check@v1.1.1
        with:
          diff-search: true
          token: ${{ secrets.GITHUB_TOKEN }}

      - name: Log when unchanged
        if: steps.check.outputs.changed != 'true'
        run: 'echo "No version change :/"'

      - name: Log when changed
        if: steps.check.outputs.changed == 'true'
        run: 'echo "Version change! -> ${{ steps.check.outputs.type }}"'

      - name: Create Release
        id: create_release
        if: steps.check.outputs.changed == 'true'
        uses: actions/create-release@v1
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          tag_name: ${{ steps.check.outputs.version }}
          release_name: ${{ steps.check.outputs.version }}
          body: |
            Changes in this Release
            - First Change
            - Second Change
          draft: false
          prerelease: false
```