### PR TITLE
Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ outputs:
     description: The SHA of the commit where the version change has been detected
 
 runs:
-  using: node12
+  using: node16
   main: 'lib/index.js'
 
 branding:


### PR DESCRIPTION
I noticed this message began showing up in my CI logs:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: EndBug/version-check